### PR TITLE
Expose exponential backoff params for scroll

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
         ci_node_index: [0]
         java: ["1.8", "11", "14"]
-        elasticsearch: ["elasticsearch:5.6.16", "elasticsearch:6.8.8", "elasticsearch:7.5.2", "elasticsearch:7.6.2"]
+        elasticsearch: ["elasticsearch:5.6.16", "elasticsearch:6.8.8", "elasticsearch:7.6.2"]
     services:
       elasticsearch:
         image: ${{ matrix.elasticsearch }}

--- a/src/scroll.clj
+++ b/src/scroll.clj
@@ -52,7 +52,7 @@
              (when error (throw (Exception. ^String (:reason error))))
              (if (<= 200 status 299)
                decoded-body
-               (throw (Exception. "Response exception")))))))))
+               (throw (Exception. "Response exception"))))))) opts))
 
 (def default-size 1000)
 (def default-query {:sort ["_doc"]})
@@ -111,6 +111,7 @@
   (log/infof "Started scrolling with: '%s'" scroll-request)
   (fetch (cond-> scroll-request
                  true (update-in [:opts :keywordize?] #(not (false? %)))
+                 true (update :opts merge default-exponential-backoff-params)
                  (not (true? (get-in scroll-request [:opts :preserve-aggs?]))) (dissoc-aggs))))
 
 (comment

--- a/test/exponential_backoff_test.clj
+++ b/test/exponential_backoff_test.clj
@@ -1,0 +1,22 @@
+(ns exponential-backoff-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.tools.logging :as log]
+            [utils :as utils]))
+
+(deftest ^:integration exponential-backoff-fail
+  (testing "if batch size is equal 0 then empty list of records should be returned with an error in the log"
+    (let [es-host (or (System/getenv "ES_HOST") "http://localhost:9200")
+          index-name "non-existing-index"
+          start (System/currentTimeMillis)]
+      (log/infof "Deleted index='%s' at '%s': %s"
+                 index-name es-host (utils/delete-index es-host index-name))
+      (try
+        (scroll/hits
+             {:es-host    es-host
+              :index-name index-name
+              :opts       {:size 1
+                           :time 1000
+                           :rate 2
+                           :max 1500}})
+        (catch Exception _
+          (is (< (- (System/currentTimeMillis) start) 2000)))))))

--- a/test/scroll_test.clj
+++ b/test/scroll_test.clj
@@ -56,9 +56,9 @@
     (testing "if query limits the number of items returned"
       (let [num-of-docs (rand-int number-of-docs)]
         (is (= num-of-docs (count (scroll/hits
-                         {:es-host    es-host
-                          :index-name index-name
-                          :query      {:query {:terms {:value (range num-of-docs)}}}}))))))
+                                    {:es-host    es-host
+                                     :index-name index-name
+                                     :query      {:query {:terms {:value (range num-of-docs)}}}}))))))
 
     (testing "if aggs dissoc works as expected"
       (let [num-of-docs (rand-int number-of-docs)]
@@ -94,7 +94,9 @@
                           {:es-host    es-host
                            :index-name index-name
                            :query      (assoc query :search_after (:sort first-record))
-                           :opts       {:size 1}}))))))
+                           :opts       {:size 1
+                                        :time 10
+                                        :max  11}}))))))
 
     (testing "if batch size is equal 0 then empty list of records should be returned with an error in the log"
       (is (= 0
@@ -102,7 +104,9 @@
                (scroll/hits
                  {:es-host    es-host
                   :index-name index-name
-                  :opts       {:size 0}})))))
+                  :opts       {:size 0
+                               :time 10
+                               :max  11}})))))
 
     ;(testing "laziness: take 5 records sleep till scroll id expires; try to take all after sleep not fail in that"
     ;  (let [records (scroll/hits

--- a/test/utils.clj
+++ b/test/utils.clj
@@ -25,6 +25,16 @@
                           (json/object-mapper {:decode-key-fn true}))))
     {:message "Index does not exist."}))
 
+(defn delete-all-scroll-contexts [es-host]
+  @(http/request
+     {:method  :delete
+      :client  @scroll/client
+      :url     (format "%s/_search/scroll/_all" es-host)
+      :headers {"Content-Type" "application/json"}}
+     (fn [resp]
+       (json/read-value (:body resp)
+                        (json/object-mapper {:decode-key-fn true})))))
+
 (defn create-index [es-host index-name]
   @(http/request
      {:method  :put


### PR DESCRIPTION
In `:opts` map it should be possible to describe how exponential backoff should behave.

closes #4 