### PR TITLE
Support Elasticsearch PIT with `search_after`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,8 @@ jobs:
         # set N-1 indexes for parallel jobs
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
         ci_node_index: [0]
-        java: ["1.8", "11", "14", "15"]
-        elasticsearch: ["elasticsearch:6.8.12", "elasticsearch:7.9.1"]
+        java: ["1.8", "11", "14"]
+        elasticsearch: ["elasticsearch:6.8.12", "elasticsearch:7.10.0"]
     services:
       elasticsearch:
         image: ${{ matrix.elasticsearch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
         ci_node_index: [0]
         java: ["1.8", "11", "14"]
-        elasticsearch: ["elasticsearch:6.8.12", "elasticsearch:7.10.0"]
+        elasticsearch: ["elasticsearch:6.8.12", "docker.elastic.co/elasticsearch/elasticsearch:7.10.0"]
     services:
       elasticsearch:
         image: ${{ matrix.elasticsearch }}

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ release:
 	rm pom.xml.releaseBackup || true
 	clojure -Spom
 	mvn release:prepare
+
+.PHONY: lint
+lint:
+	clojure -M:clj-kondo

--- a/deps.edn
+++ b/deps.edn
@@ -14,6 +14,10 @@
                  criterium/criterium            {:mvn/version "0.4.6"}
                  ch.qos.logback/logback-core    {:mvn/version "1.2.3"}
                  ch.qos.logback/logback-classic {:mvn/version "1.2.3"}}}
+  :clj-kondo
+  {:main-opts  ["-m" "clj-kondo.main --lint src test"]
+   :extra-deps {clj-kondo/clj-kondo {:mvn/version "2020.11.07"}}
+   :jvm-opts   ["-Dclojure.main.report=stderr"]}
   :test
   {:extra-paths ["test" "test/resources"]
    :extra-deps  {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,10 +1,10 @@
-FROM clojure:tools-deps-alpine
+FROM clojure:openjdk-14-tools-deps-1.10.1.727-slim-buster
 
 RUN mkdir /root/.gitlibs
 
 WORKDIR /usr/src/app
-COPY deps.edn /usr/src/core/
+COPY deps.edn /usr/src/app
 
-RUN clojure -A:dev:test || true
+RUN clojure -P -M:dev:test
 
 COPY . /usr/src/app

--- a/dockerfiles/docker-compose.es.test.yml
+++ b/dockerfiles/docker-compose.es.test.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:${ES_VERSION:-7.10.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-7.10.0}
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true

--- a/dockerfiles/docker-compose.es.test.yml
+++ b/dockerfiles/docker-compose.es.test.yml
@@ -19,4 +19,4 @@ services:
       dockerfile: dockerfiles/Dockerfile.test
     environment:
       ES_HOST: http://elasticsearch:9200
-    command: ["clojure", "-A:dev:test", "-i", "integration"]
+    command: ["clojure", "-M:dev:test", "-i", "integration"]

--- a/src/scroll.clj
+++ b/src/scroll.clj
@@ -61,17 +61,17 @@
         pit (pit/init es-host index-name opts)
         latest-pit-id (atom (:id pit))
         pit-with-keep-alive (assoc pit :keep_alive (or (:keep-alive opts) "30s"))]
-    (lazy-cat
-      (take 1
-            (hits
-              {:es-host    es-host
-               :index-name index-name
-               :query      (assoc {:query {:match_all {}}} :pit pit-with-keep-alive)
-               :opts       {:strategy      :search-after
-                            :keywordize?   true
-                            :size          1
-                            :latest-pit-id latest-pit-id}}))
-      (do
-        (log/debugf "PIT terminated with: %s"
-                    (pit/terminate es-host {:id @latest-pit-id}))
-        nil))))
+    (last
+      (lazy-cat
+        (hits
+          {:es-host    es-host
+           :index-name index-name
+           :query      (assoc {:query {:match_all {}}} :pit pit-with-keep-alive)
+           :opts       {:strategy      :search-after
+                        :keywordize?   true
+                        :size          10
+                        :latest-pit-id latest-pit-id}})
+        (do
+          (log/debugf "PIT terminated with: %s"
+                      (pit/terminate es-host {:id @latest-pit-id}))
+          nil)))))

--- a/src/scroll.clj
+++ b/src/scroll.clj
@@ -73,4 +73,5 @@
                             :latest-pit-id latest-pit-id}}))
       (do
         (log/debugf "PIT terminated with: %s"
-                    (pit/terminate es-host {:id @latest-pit-id}))))))
+                    (pit/terminate es-host {:id @latest-pit-id}))
+        nil))))

--- a/src/scroll/pit.clj
+++ b/src/scroll/pit.clj
@@ -1,5 +1,6 @@
 (ns scroll.pit
-  (:require [org.httpkit.client :as http]
+  (:require [clojure.tools.logging :as log]
+            [org.httpkit.client :as http]
             [jsonista.core :as json]))
 
 (def mapper (json/object-mapper {:decode-key-fn true}))
@@ -14,6 +15,7 @@
       (fn [resp] (json/read-value (:body resp) mapper)))))
 
 (defn terminate [es-host pit]
+  (log/debugf "Terminating PIT: %s" pit)
   @(http/request
      {:method :delete
       :headers {"Content-Type" "application/json"}

--- a/src/scroll/pit.clj
+++ b/src/scroll/pit.clj
@@ -16,12 +16,16 @@
   ([es-host pit] (terminate es-host pit {}))
   ([es-host pit opts]
    (log/debugf "Terminating PIT: %s" pit)
-   (request/execute-request
-     {:method :delete
-      :url    (format "%s/_pit" es-host)
-      :body   pit
-      :opts   (merge request/default-exponential-backoff-params
-                     (assoc opts :keywordize? true))})))
+   (try
+     (request/execute-request
+       {:method :delete
+        :url    (format "%s/_pit" es-host)
+        :body   pit
+        :opts   (merge request/default-exponential-backoff-params
+                       (assoc opts :keywordize? true
+                                   :max 1000))})
+     (catch Exception _
+       {:succeeded false}))))
 
 (comment
   (scroll.pit/init "http://localhost:9200" ".kibana")

--- a/src/scroll/pit.clj
+++ b/src/scroll/pit.clj
@@ -1,0 +1,28 @@
+(ns scroll.pit
+  (:require [org.httpkit.client :as http]
+            [jsonista.core :as json]))
+
+(def mapper (json/object-mapper {:decode-key-fn true}))
+
+(defn init
+  ([es-host index-name] (init es-host index-name {}))
+  ([es-host index-name opts]
+   @(http/request
+      {:method :post
+       :url    (format "%s/%s/_pit?keep_alive=%s"
+                       es-host index-name (or (:keep-alive opts) "1m"))}
+      (fn [resp] (json/read-value (:body resp) mapper)))))
+
+(defn terminate [es-host pit]
+  @(http/request
+     {:method :delete
+      :headers {"Content-Type" "application/json"}
+      :url    (format "%s/_pit" es-host)
+      :body (json/write-value-as-string pit)}
+     (fn [resp]
+       (json/read-value (:body resp) mapper))))
+
+(comment
+  (scroll.pit/init "http://localhost:9200" ".kibana")
+
+  (scroll.pit/terminate "http://localhost:9200" (scroll.pit/init "http://localhost:9200" ".kibana")))

--- a/src/scroll/request.clj
+++ b/src/scroll/request.clj
@@ -36,18 +36,22 @@
 
 (def client (delay (http/make-client {:ssl-configurer sni-configure})))
 
+(def default-headers {"Content-Type"  "application/json"})
+
 (defn authorization-token []
-  (.encodeToString (Base64/getEncoder)
-                   (.getBytes (str (System/getenv "ELASTIC_USERNAME")
-                                   ":"
-                                   (System/getenv "ELASTIC_PASSWORD")))))
-(defn prepare-headers [_]
+  (let [username (System/getenv "ELASTIC_USERNAME")
+        password (System/getenv "ELASTIC_PASSWORD")]
+    (when (and username password)
+      (.encodeToString (Base64/getEncoder) (.getBytes (str username ":" password))))))
+
+(defn prepare-headers [headers _]
   ; basic authorization
   ; https://www.elastic.co/guide/en/elasticsearch/reference/current/http-clients.html
-  {"Content-Type"  "application/json"
-   "Authorization" (str "Basic " (authorization-token))})
+  (if-let [auth-token (authorization-token)]
+    (assoc headers "Authorization" (str "Basic " auth-token))
+    headers))
 
-(defn execute-request [{:keys [url body opts method]}]
+(defn execute-request [{:keys [url body opts method headers]}]
   (exponential-backoff
     (fn []
       (let [{:keys [status body error]}
@@ -55,7 +59,7 @@
                (cond-> {:method  (or method :get)
                         :client  @client
                         :url     url
-                        :headers (prepare-headers opts)}
+                        :headers (prepare-headers (or headers default-headers) opts)}
                        (not (nil? body)) (assoc :body (json/write-value-as-string body))))]
         (when error (throw (Exception. (str error))))
         (when-not (str/blank? body)

--- a/src/scroll/request.clj
+++ b/src/scroll/request.clj
@@ -54,7 +54,7 @@
 (defn execute-request [{:keys [url body opts method headers]}]
   (exponential-backoff
     (fn []
-      (let [{:keys [status body error]}
+      (let [{:keys [status body error] :as resp}
             @(http/request
                (cond-> {:method  (or method :get)
                         :client  @client
@@ -70,5 +70,5 @@
             (when error (throw (Exception. (str error))))
             (if (<= 200 status 299)
               decoded-body
-              (throw (Exception. (format "Response exception: %s" (str decoded-body)))))))))
+              (throw (Exception. (format "Response exception: %s" resp))))))))
     (or opts default-exponential-backoff-params)))

--- a/src/scroll/request.clj
+++ b/src/scroll/request.clj
@@ -66,5 +66,5 @@
             (when error (throw (Exception. (str error))))
             (if (<= 200 status 299)
               decoded-body
-              (throw (Exception. (format "Response exception" (str decoded-body)))))))))
+              (throw (Exception. (format "Response exception: %s" (str decoded-body)))))))))
     (or opts default-exponential-backoff-params)))

--- a/src/scroll/search_after.clj
+++ b/src/scroll/search_after.clj
@@ -2,7 +2,8 @@
   (:require [clojure.tools.logging :as log]
             [scroll.batch :as batch]
             [scroll.hits :as hits]
-            [scroll.request :as request]))
+            [scroll.request :as request])
+  (:import (clojure.lang IAtom)))
 
 (def default-query {:sort ["_doc"]})
 
@@ -59,7 +60,7 @@
                   (or fetched 0)
                   (get req :total-count)
                   (or (get batch :took) (get batch "took")))
-      (when (:latest-pit-id opts)
+      (when (instance? IAtom (:latest-pit-id opts))
         (reset! (:latest-pit-id opts) (extract-pit-id batch (get opts :keywordize?))))
       (when-let [current-hits (seq (hits/extract-hits batch (get opts :keywordize?)))]
         (lazy-cat current-hits

--- a/src/scroll/search_after.clj
+++ b/src/scroll/search_after.clj
@@ -15,12 +15,11 @@
     (format "%s/%s/_search" es-host (or index-name "*"))))
 
 (defn prepare-query-body [query opts]
-  (remove-from-param
-    (batch/set-batch-size
-      (if (:sort query)
-        (or query default-query)
-        (merge query default-query))
-      opts)))
+  (cond-> (or query default-query)
+          (nil? (:sort query)) (merge default-query)
+          true (batch/set-batch-size opts)
+          true (remove-from-param)
+          true (assoc :track_total_hits true)))
 
 (defn start [es-host index-name query opts]
   (request/execute-request
@@ -46,18 +45,28 @@
 (defn extract-pit-id [batch keywordize?]
   (get batch (if keywordize? :pit_id "pit_id")))
 
-(defn fetch [{:keys [es-host index-name query search-after opts] :as req}]
+(defn fetch [{:keys [es-host index-name query search-after fetched total-count opts] :as req}]
   (try
     (let [batch (if search-after
                   (continue es-host index-name query search-after opts)
-                  (start es-host index-name query opts))]
-      (log/debugf "Fetching a batch took: %s ms" (or (get batch :took) (get batch "took")))
+                  (start es-host index-name query opts))
+          req (if search-after
+                req
+                (assoc req :total-count (if (get opts :keywordize?)
+                                          (get-in batch [:hits :total :value])
+                                          (get-in batch ["hits" "total" "value"]))))]
+      (log/debugf "Fetching a batch from '%s' out of '%s' took: %s ms"
+                  (or fetched 0)
+                  (or total-count (get req :total-count))
+                  (or (get batch :took) (get batch "took")))
       (when (:latest-pit-id opts)
         (reset! (:latest-pit-id opts) (extract-pit-id batch (get opts :keywordize?))))
       (when-let [current-hits (seq (hits/extract-hits batch (get opts :keywordize?)))]
         (lazy-cat current-hits
                   (when-let [sa (extract-search-after batch (get opts :keywordize?))]
-                    (fetch (assoc req :search-after sa))))))
+                    (fetch (-> req
+                               (assoc :search-after sa)
+                               (assoc :fetched (+ (or fetched 0) (count current-hits)))))))))
     (catch Exception e
       (.printStackTrace e)
       (log/errorf "Failed to search_after: %s" e)

--- a/src/scroll/search_after.clj
+++ b/src/scroll/search_after.clj
@@ -45,7 +45,7 @@
 (defn extract-pit-id [batch keywordize?]
   (get batch (if keywordize? :pit_id "pit_id")))
 
-(defn fetch [{:keys [es-host index-name query search-after fetched total-count opts] :as req}]
+(defn fetch [{:keys [es-host index-name query search-after fetched opts] :as req}]
   (try
     (let [batch (if search-after
                   (continue es-host index-name query search-after opts)
@@ -57,7 +57,7 @@
                                           (get-in batch ["hits" "total" "value"]))))]
       (log/debugf "Fetching a batch from '%s' out of '%s' took: %s ms"
                   (or fetched 0)
-                  (or total-count (get req :total-count))
+                  (get req :total-count)
                   (or (get batch :took) (get batch "took")))
       (when (:latest-pit-id opts)
         (reset! (:latest-pit-id opts) (extract-pit-id batch (get opts :keywordize?))))

--- a/test/scroll/pit_test.clj
+++ b/test/scroll/pit_test.clj
@@ -1,5 +1,5 @@
 (ns scroll.pit-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [clojure.tools.logging :as log]
             [scroll.pit :as pit]
             [utils :as utils]))
@@ -10,4 +10,7 @@
     (log/infof "Index recreated %s" (utils/recreate-index es-host index-name))
     (let [pit-resp (pit/init es-host index-name)]
       (is (string? (:id pit-resp)))
-      (is (true? (:succeeded (pit/terminate es-host pit-resp)))))))
+      (is (true? (:succeeded (pit/terminate es-host pit-resp))))
+
+      (testing "Terminating PIT second time is not successful"
+        (is (false? (:succeeded (pit/terminate es-host pit-resp))))))))

--- a/test/scroll/pit_test.clj
+++ b/test/scroll/pit_test.clj
@@ -1,0 +1,12 @@
+(ns scroll.pit-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.tools.logging :as log]
+            [scroll.pit :as pit]))
+
+(deftest ^:integration pit-client
+  (let [es-host (or (System/getenv "ES_HOST") "http://localhost:9200")
+        index-name "scroll-test-index"]
+    (log/infof "Index recreated %s" (utils/recreate-index es-host index-name))
+    (let [pit-resp (pit/init es-host index-name)]
+      (is (string? (:id pit-resp)))
+      (is (true? (:succeeded (pit/terminate es-host pit-resp)))))))

--- a/test/scroll/pit_test.clj
+++ b/test/scroll/pit_test.clj
@@ -6,11 +6,14 @@
 
 (deftest ^:integration pit-client
   (let [es-host (or (System/getenv "ES_HOST") "http://localhost:9200")
-        index-name "pit-test-index"]
-    (log/infof "Index recreated %s" (utils/recreate-index es-host index-name))
-    (let [pit-resp (pit/init es-host index-name)]
-      (is (string? (:id pit-resp)))
-      (is (true? (:succeeded (pit/terminate es-host pit-resp))))
+        index-name "pit-test-index"
+        semantic-version (utils/semantic-es-version es-host)]
+    (when (and (<= 7 (:major semantic-version))
+               (<= 10 (:minor semantic-version)))
+      (log/infof "Index recreated %s" (utils/recreate-index es-host index-name))
+      (let [pit-resp (pit/init es-host index-name)]
+        (is (string? (:id pit-resp)))
+        (is (true? (:succeeded (pit/terminate es-host pit-resp))))
 
-      (testing "Terminating PIT second time is not successful"
-        (is (false? (:succeeded (pit/terminate es-host pit-resp))))))))
+        (testing "Terminating PIT second time is not successful"
+          (is (false? (:succeeded (pit/terminate es-host pit-resp)))))))))

--- a/test/scroll/pit_test.clj
+++ b/test/scroll/pit_test.clj
@@ -1,11 +1,12 @@
 (ns scroll.pit-test
   (:require [clojure.test :refer [deftest is]]
             [clojure.tools.logging :as log]
-            [scroll.pit :as pit]))
+            [scroll.pit :as pit]
+            [utils :as utils]))
 
 (deftest ^:integration pit-client
   (let [es-host (or (System/getenv "ES_HOST") "http://localhost:9200")
-        index-name "scroll-test-index"]
+        index-name "pit-test-index"]
     (log/infof "Index recreated %s" (utils/recreate-index es-host index-name))
     (let [pit-resp (pit/init es-host index-name)]
       (is (string? (:id pit-resp)))

--- a/test/scroll_test.clj
+++ b/test/scroll_test.clj
@@ -9,7 +9,7 @@
 (deftest ^:integration search-after-strategy
   (let [es-host (or (System/getenv "ES_HOST") "http://localhost:9200")
         index-name "scroll-test-index"
-        number-of-docs (+ 10 (rand-int 0))
+        number-of-docs (+ 10 (rand-int 10))
         records (map (fn [x] {:_id x
                               :_source {:value x}}) (range number-of-docs))]
     (log/infof "Deleted index='%s' at '%s': %s"

--- a/test/utils.clj
+++ b/test/utils.clj
@@ -3,7 +3,6 @@
     [clojure.string :as string]
     [jsonista.core :as json]
     [org.httpkit.client :as http]
-    [scroll.request :as scroll]
     [scroll.request :as request])
   (:import (java.util UUID)))
 
@@ -16,7 +15,7 @@
   (if (index-exists? es-host index-name)
     @(http/request
        {:method  :delete
-        :client  @scroll/client
+        :client  @request/client
         :url     (format "%s/%s" es-host index-name)
         :headers {"Content-Type" "application/json"}}
        (fn [resp]
@@ -27,7 +26,7 @@
 (defn create-index [es-host index-name]
   @(http/request
      {:method  :put
-      :client  @scroll/client
+      :client  @request/client
       :url     (format "%s/%s" es-host index-name)
       :headers {"Content-Type" "application/json"}
       :body    (json/write-value-as-string {:settings
@@ -41,7 +40,7 @@
 (defn refresh-index [dest-host dest-index]
   @(http/request
      {:method  :get
-      :client  @scroll/client
+      :client  @request/client
       :url     (format "%s/%s/_refresh" dest-host dest-index)
       :headers {"Content-Type" "application/json"}}
      (fn [resp]
@@ -49,7 +48,7 @@
                         (json/object-mapper {:decode-key-fn true})))))
 
 (defn es-version [es-host]
-  @(org.httpkit.client/request
+  @(http/request
      {:method :get
       :url    es-host}
      #(-> (:body %)
@@ -85,6 +84,7 @@
   @(http/request
      {:url       (format "%s/_bulk" es-host)
       :method    :post
+      :client    @request/client
       :headers   {"Content-Type" "application/x-ndjson"}
       :body      body
       :keepalive 30000}

--- a/test/utils.clj
+++ b/test/utils.clj
@@ -3,15 +3,14 @@
     [clojure.string :as string]
     [jsonista.core :as json]
     [org.httpkit.client :as http]
-    [scroll.request :as scroll])
+    [scroll.request :as scroll]
+    [scroll.request :as request])
   (:import (java.util UUID)))
 
 (defn index-exists? [es-host index-name]
-  @(http/request
-     {:method :head
-      :client @scroll/client
-      :url    (format "%s/%s" es-host index-name)}
-     (fn [resp] (not (= 404 (:status resp))))))
+  (not (= 404 (:status (request/execute-request
+                           {:method :head
+                            :url (format "%s/%s" es-host index-name)})))))
 
 (defn delete-index [es-host index-name]
   (if (index-exists? es-host index-name)

--- a/test/utils.clj
+++ b/test/utils.clj
@@ -37,6 +37,10 @@
        (json/read-value (:body resp)
                         (json/object-mapper {:decode-key-fn true})))))
 
+(defn recreate-index [es-host index-name]
+  (delete-index es-host index-name)
+  (create-index es-host index-name))
+
 (defn refresh-index [dest-host dest-index]
   @(http/request
      {:method  :get


### PR DESCRIPTION
Combining the `search_after` with PIT is the recommended way to implement deep paging.

closes #37 